### PR TITLE
Remove background color on html element

### DIFF
--- a/newtab/newtab.css
+++ b/newtab/newtab.css
@@ -7,7 +7,6 @@ html {
 	align-items: center;
 	justify-content: center;
 
-	background: #22313F;
 	color: #ECECEC;
 	font-size: 1.5vh;
 }


### PR DESCRIPTION
The custom background color (the black color) I chose does not fill the whole page:

![Image of issue](http://i.imgur.com/7M3uDfp.png)

This commits removes the background color from the html element so the background color fills the whole page